### PR TITLE
fix: configfile check

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -7,9 +7,25 @@ import sys
 
 #  check that config file is provided
 def check_configfile():
-    if "--configfile" not in sys.argv:
-        raise ValueError("Please specify a config file using the --configfile flag.")
+    try:
+        msg = f"""
+----------- loading config file -----------
+--- run config:
+{config["run_config"]}
 
+--- pileup
+{config["pileup"]}
+
+--- plots
+{config["plots"]}
+-------------------------------------------
+
+"""
+        print(msg)
+    except:
+        raise Exception("config file not specified. Please specify with --configfile flag.")
+    
+    
 
 check_configfile()
 

--- a/test_data/run_config.yml
+++ b/test_data/run_config.yml
@@ -1,12 +1,19 @@
 run_config:
-  input: "test_data/input-test-leo"
-  output: "test_data/output-test-leo"
+  input: "test_data/input"
+  output: "test_data/output"
   pileups:
-    reference_ST131I:
-    - "sample1"
-    - "sample2"
-    - "sample3"
-    - "sample4"
+    EC2D2_assembled:
+    - "EC2D2_1"
+    - "EC2D2_3"
+    - "EC2D2_5"
+    EM11_assembled:
+    - "EM11_1"
+    - "EM11_3"
+    - "EM11_5"
+    EM60_assembled:
+    - "EM60_1"
+    - "EM60_3"
+    - "EM60_5"
 pileup:
   qual_min: 15
   clip_minL: 100


### PR DESCRIPTION
with the new configfile setup the pipeline fails on cluster execution because the check for the presence of `--configfile` flag gets re-executed for every submitted job.
Changed the check to be compatible with cluster execution.